### PR TITLE
Add support for extensions to esctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,56 @@
-# esctl-go
-
-A command line client built on [go-elasticsearch](https://github.com/elastic/go-elasticsearch) for interacting with elasticsearch clusters.
+# esctl
 
 [![GoDoc](https://godoc.org/github.com/geoffmore/esctl-go?status.svg)](http://godoc.org/github.com/geoffmore/esctl-go)
 [![CircleCI](https://circleci.com/gh/geoffmore/esctl-go.svg?style=svg)](https://circleci.com/gh/geoffmore/esctl-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/geoffmore/esctl-go)](https://goreportcard.com/report/github.com/geoffmore/esctl-go)
 
+----
+
+esctl is a command line client built on [go-elasticsearch](https://github.com/elastic/go-elasticsearch) for interacting with elasticsearch clusters.
+
+## Getting started
+### Install
+Run one of 
+* `./build/make-build.sh` to build only core features
+* `./build/make-buildext.sh` to build core features and extensions
+* `./build/make-build-opt.sh` to build core features and all optional features
+  (including extensions)
+You will end up with a binary `esctl` that can then be put into your $PATH
+### Initializing
+Run `esctl config generate` to generate a config file at `~/.elastic/config` with a similar structure to
+[kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig) 
+
 ## Usage
-For each of these commands talks to a specific elasticsearch endpoint. Rather
-than explaining each command, the appropriate endpoint will instead be shown.
+Every command has a list of its subcommands and usually correspond to an elastic
+endpoint. For example, the `cat` command corresponds to `/_cat/` and `cat
+pending-tasks` corresponds to `/_cat/pending_tasks`
+
+### Available commands
+#### Core
+```
+  cat         Endpoints under /_cat
+  config      Interact with a config file
+  get         Get a resource
+  help        Help about any command
+  version     Print the version number of esctl client/server
+```
+#### Extensions
+```
+  kibana (planned)  Kibana endpoints
+  admin (planned)   Useful commands for elasticsearch administrators
+```
+## Contributing
+In the case of contributing to the core tool or existing extensions, you should
+raise an issue,
+fork the repo, 
+and submit a PR referencing the issue
+
+In the case of extending the tool, you should
+create an extension by doing the following:
+Run `./build/gen-extension.sh \<your-extension/package name\>`
+Build!
+
+## List of current and future features
+See [this](TODO.md)
 
 [This link](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api) may be a valuable resource in seeing which api endpoints are avaiable.
-
-| Command | Endpoint |
-| --- | --- |
-| esctl get cluster-info | / |
-| esctl get cluster-health | /_cluster/health |
-
-## TODO
-See [this](TODO.md)

--- a/TODO.md
+++ b/TODO.md
@@ -8,12 +8,17 @@ Todo list for esctl-go
 - [x] Add CI for building packages
 - [x] Add common badges to README
 - [ ] Add ability to switch between elastic clusters
+  * [x] Via command
+  * [ ] Via flag
 - [ ] Add automatic documentation for command usage (https://godoc.org/github.com/spf13/cobra/doc)
-- [ ] Make top level command `esctl` display avaiable subcommands if no
+- [x] Make top level command `esctl` display avaiable subcommands if no
   arguments are present
-- [ ] Make second level command `esctl get` display available subcommands if no
+- [x] Make second level command `esctl get` display available subcommands if no
   arguements are present
 - [ ] Determine which verbs `esctl` should use other than `get`
+- [x] Add support for optional modules at compile time
+  * [x] Create a script to initialize new modules
+  * [x] Create a Makefile that allows compilation of optional modules
 
 ## Function porting from https://github.com/slmingol/escli/blob/master/es_funcs.bash
 - [ ] escli_ls

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,25 @@
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build -o $(BINARY_NAME) -v
+BINARY_NAME=esctl
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) get
+
+all: build
+
+build:
+	@echo "Building with no extensions or optional files"
+	$(GOBUILD) 
+	@echo "Done!"
+build-opt: 
+	@echo "Building with all optional files..."
+	$(GOBUILD) -tags optional
+	@echo "Done!"
+build-ext:
+	@echo "Building with extensions..."
+	$(GOBUILD) -tags ext
+	@echo "Done!"
+
+clean:
+	$(GOCLEAN)
+	rm -f $(BINARY_NAME)

--- a/build/extension/cmd.tmpl
+++ b/build/extension/cmd.tmpl
@@ -1,0 +1,48 @@
+// +build optional ext {{ .pkg }}
+
+package cmd
+
+import (
+   "github.com/geoffmore/esctl-go/pkg/{{ .pkg }}"
+   "log"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand({{ .pkg }}Cmd)
+   {{ .pkg }}Cmd.AddCommand({{ .pkg }}Test)
+   {{ .pkg }}Cmd.AddCommand({{ .pkg }}Int)
+}
+
+var {{ .pkg }}Cmd = &cobra.Command{
+	// esctl {{ .pkg }}
+	Use:   "{{ .pkg }}",
+	Short: "No description",
+}
+
+var {{ .pkg }}Test = &cobra.Command{
+	// esctl {{ .pkg }} test
+	Use:   "test-cmd",
+	Short: "Generated code to demonstrate project structure",
+	Run: func(cmd *cobra.Command, args []string) {
+		{{ .pkg }}.CmdTest()
+	},
+}
+
+var {{ .pkg }}Int = &cobra.Command{
+	// esctl {{ .pkg }} test
+	Use:   "test-int",
+	Short: "Generated code to demonstrate project structure",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Boilerplate
+		client, err := genClient()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = {{ .pkg }}.IntegrationTest(client)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/build/extension/main.tmpl
+++ b/build/extension/main.tmpl
@@ -1,0 +1,24 @@
+// +build optional ext {{ .pkg }}
+
+package {{ .pkg }}
+
+import (
+  "fmt"
+  elastic7 "github.com/elastic/go-elasticsearch/v7"
+  "github.com/elastic/go-elasticsearch/v7/esapi"
+  "github.com/geoffmore/esctl-go/esutil"
+)
+
+func CmdTest(){
+  fmt.Println("Test")
+}
+
+func IntegrationTest(esClient *elastic7.Client) error {
+	req := esapi.ClusterHealthRequest{
+		Pretty: true,
+      Human: true,
+	}
+
+	err := esutil.Request(req, esClient)
+	return err
+}

--- a/build/extension/types.tmpl
+++ b/build/extension/types.tmpl
@@ -1,0 +1,3 @@
+// +build optional ext {{ .pkg }}
+
+package {{ .pkg }}

--- a/build/gen-extension.sh
+++ b/build/gen-extension.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Argument count check
+if [[ ${#@} -lt 1 ]]; then
+  echo "Insufficient number of arguments for command"
+  exit 1
+fi
+
+PKG="${1}"
+OUTPUT_BIN="tmp-esctl"
+
+# Argument validation
+grep -E "^[a-z]{3,}$"  <<< "$PKG"
+if [[ "$?" -ne 0 ]]; then
+  echo "Package name needs to be lower case, with no under_scores or mixedCaps (https://blog.golang.org/package-names) and have at least 3 characters"
+  exit 1
+fi
+
+echo "Attemping to template files..."
+# Add the pkg to pkg dir
+ mkdir -p pkg/${PKG}
+# Add the template value to file
+echo "pkg: ${PKG}" > pkg.yml
+# Create and place template files (safely)
+set -o noclobber
+gotpl build/extension/cmd.tmpl   < pkg.yml > cmd/${PKG}.go
+gotpl build/extension/main.tmpl  < pkg.yml > pkg/${PKG}/${PKG}.go
+gotpl build/extension/types.tmpl < pkg.yml > pkg/${PKG}/types.go
+rm pkg.yml
+set +o noclobber
+echo "Done!"
+
+
+# Test the new package in a build
+echo "Building package with new module..."
+go build -tags ${PKG} -o "./${OUTPUT_BIN}" || echo "Compilation was not successful with new package"
+
+# Test functionality with commands
+# test-int assumes connectivity to an existing cluster. This is a bad test and
+# should rely on default configuration and a test container. Without the
+# context feature, this may not be possible without moving files around
+"./${OUTPUT_BIN}" ${PKG} test-cmd > /dev/null 2>&1 \
+  && "./${OUTPUT_BIN}" ${PKG} test-int > /dev/null 2>&1
+
+case $? in
+  0)
+    echo "Tests were successful. Enjoy extending esctl!"
+    ;;
+  *)
+    echo "Tests were not successful. Further debugging is needed..."
+    ;;
+esac
+
+# Clean up (remove binary)
+rm "./${OUTPUT_BIN}"

--- a/build/make-build-ext.sh
+++ b/build/make-build-ext.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make -f build/Makefile build-ext

--- a/build/make-build-opt.sh
+++ b/build/make-build-opt.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make -f build/Makefile build-opt

--- a/build/make-build.sh
+++ b/build/make-build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make -f build/Makefile build


### PR DESCRIPTION
To support different use cases, code has been rearchitected to support
optionally added packages. This was done to promote extending the tool
while allowing users the flexibility to only add what they want. Today's
use cases are a administrator-focused set of funcs (most of escli) and
Kibana endpoints, but will likely extend to other contributor's ideas as
well.

In addition to this, documentation was updated to better onboard new
users and TODO.md has been updated to reflect the current feature state
of esctl